### PR TITLE
fix: append OUTPUT chain after HyperOS/QCom mangle hooks

### DIFF
--- a/app/src/main/kotlin/engine/tproxy/TproxyIptablesScript.kt
+++ b/app/src/main/kotlin/engine/tproxy/TproxyIptablesScript.kt
@@ -100,7 +100,7 @@ private fun StringBuilder.appendIptablesVariantSetupRules(
         ${variant.command} -t mangle -N ${variant.preroutingChain} 2>/dev/null || true
         ${variant.command} -t mangle -N ${variant.outputChain} 2>/dev/null || true
         ${variant.command} -t mangle -I PREROUTING 1 -j ${variant.preroutingChain}
-        ${variant.command} -t mangle -I OUTPUT 1 -j ${variant.outputChain}
+        ${variant.command} -t mangle -A OUTPUT -j ${variant.outputChain}
         """,
     )
     if (config.enableEbpfRules) {

--- a/app/src/main/kotlin/engine/tun2socks/Tun2SocksIptablesScript.kt
+++ b/app/src/main/kotlin/engine/tun2socks/Tun2SocksIptablesScript.kt
@@ -81,7 +81,7 @@ private fun StringBuilder.appendIptablesVariantSetupRules(
         ${variant.command} -t mangle -N ${variant.outputChain} 2>/dev/null || true
         ${variant.command} -t filter -N ${variant.forwardChain} 2>/dev/null || true
         ${variant.command} -t mangle -I PREROUTING 1 -j ${variant.preroutingChain}
-        ${variant.command} -t mangle -I OUTPUT 1 -j ${variant.outputChain}
+        ${variant.command} -t mangle -A OUTPUT -j ${variant.outputChain}
         ${variant.command} -t filter -I FORWARD 1 -j ${variant.forwardChain}
         ${variant.command} -t filter -A ${variant.forwardChain} -i 'asterisk0' -j ACCEPT
         ${variant.command} -t filter -A ${variant.forwardChain} -o 'asterisk0' -j ACCEPT


### PR DESCRIPTION
## Problem

On HyperOS (and other Qualcomm-based ROMs), tun root mode and tproxy mode fail on WiFi — traffic does not flow through the proxy core. Switching to mobile data and back temporarily fixes it.

## Root Cause

HyperOS inserts custom mangle chains into the OUTPUT chain (tc_wmm, qcom_NWMGR, connmark_mangle_OUTPUT, etc.). The proxy OUTPUT chain was inserted at position 1 (-I OUTPUT 1), before these vendor hooks.

In particular, tc_wmm's final rule (MARK and 0x9fffffff) clears bits 29-30, which exactly overlaps with the proxy fwmark 0x20000000/0x60000000. This erases the fwmark after the proxy chain sets it, causing all proxied traffic to bypass the tun device and go direct.

The temporary fix on network switch happens because Android's netd rebuilds vendor chains, temporarily changing the behavior.

## Fix

Change -I OUTPUT 1 to -A OUTPUT so the proxy chain runs last, after all vendor hooks have finished modifying fwmark.

PREROUTING stays as -I PREROUTING 1 since there are no vendor hooks clearing fwmark in that chain.

## Verification

Confirmed on HyperOS device:
- tc_wmm chain has (MARK and 0x9fffffff) as final rule
- Moving ASTERISK_TUN_OUTPUT to end of OUTPUT chain immediately fixed tun root mode and tproxy mode on WiFi
- BPF2SOCKS mode is unaffected (uses cgroup BPF socket redirect, not iptables fwmark routing)

## Files Changed

- engine/tun2socks/Tun2SocksIptablesScript.kt: -I OUTPUT 1 to -A OUTPUT
- engine/tproxy/TproxyIptablesScript.kt: -I OUTPUT 1 to -A OUTPUT