### PR TITLE
feat: FakeIP/DNS cache persistence and DNS group server support

### DIFF
--- a/app/src/main/kotlin/app/AppState.kt
+++ b/app/src/main/kotlin/app/AppState.kt
@@ -106,6 +106,8 @@ data class AppState(
     val dnsDisableCache: Boolean = false,
     val dnsDisableExpire: Boolean = false,
     val dnsTimeout: String = DefaultSingBoxDnsTimeout,
+    val storeFakeIp: Boolean = false,
+    val storeDns: Boolean = false,
     val dnsServers: List<SingBoxDnsServerState> = DefaultSingBoxDnsServers,
     val nextDnsServerId: Int =
         (DefaultSingBoxDnsServers.maxOfOrNull(SingBoxDnsServerState::id) ?: 0) + 1,

--- a/app/src/main/kotlin/app/AppStateModels.kt
+++ b/app/src/main/kotlin/app/AppStateModels.kt
@@ -246,6 +246,7 @@ data class SingBoxDnsServerState(
     val detour: String = "",
     val tlsServerName: String = "",
     val tlsInsecure: Boolean = false,
+    val servers: List<String> = emptyList(),
 ) {
     val tag: String
         get() = managedDnsServerTag(id)
@@ -289,6 +290,7 @@ data class SingBoxDnsRuleState(
 val SingBoxDnsServerTypes = listOf(
     "local",
     "hosts",
+    "group",
     "udp",
     "tcp",
     "tls",

--- a/app/src/main/kotlin/app/AppStateReferences.kt
+++ b/app/src/main/kotlin/app/AppStateReferences.kt
@@ -451,6 +451,17 @@ internal fun AppState.withPrunedDnsServerReferences(): AppState {
         routeDefaultDomainResolver = routeDefaultDomainResolver
             .takeIf { tag -> tag.isBlank() || tag in availableTags }
             .orEmpty(),
+        dnsServers = dnsServers
+            .map { server ->
+                if (server.type == "group") {
+                    val pruned = server.servers
+                        .filter { member -> member in availableTags && member != server.tag }
+                    if (pruned == server.servers) server else server.copy(servers = pruned)
+                } else {
+                    server
+                }
+            }
+            .filterNot { server -> server.type == "group" && server.servers.isEmpty() },
         outbounds = outbounds.clearUnavailableManagedReferences(
             field = "domain_resolver",
             availableTags = availableTags,
@@ -485,16 +496,24 @@ internal fun AppState.withRemovedManagedDnsServers(
         if (dependentTags.isEmpty()) break
         unavailableTags += dependentTags
     }
-    val remainingServers = dnsServers.filterNot { server -> server.tag in unavailableTags }
+    val remainingServers = dnsServers
+        .filterNot { server -> server.tag in unavailableTags }
+        .map { server ->
+            server.copy(
+                domainResolver = server.domainResolver
+                    .takeUnless(unavailableTags::contains)
+                    .orEmpty(),
+                servers = if (server.type == "group") {
+                    server.servers.filterNot(unavailableTags::contains)
+                } else {
+                    server.servers
+                },
+            )
+        }
+        .filterNot { server -> server.type == "group" && server.servers.isEmpty() }
     if (remainingServers.size == dnsServers.size) return this
     return copy(
-        dnsServers = remainingServers.map { server ->
-            if (server.domainResolver in unavailableTags) {
-                server.copy(domainResolver = "")
-            } else {
-                server
-            }
-        },
+        dnsServers = remainingServers,
         dnsFinal = if (dnsFinal in unavailableTags) {
             remainingServers.firstOrNull()?.tag.orEmpty()
         } else {

--- a/app/src/main/kotlin/data/AppSettingsPreferences.kt
+++ b/app/src/main/kotlin/data/AppSettingsPreferences.kt
@@ -207,6 +207,8 @@ internal class AppSettingsPreferences(
             ),
             dnsTimeout = preferences.getString(KeyDnsTimeout, defaults.dnsTimeout)
                 ?: defaults.dnsTimeout,
+            storeFakeIp = preferences.getBoolean(KeyStoreFakeIp, defaults.storeFakeIp),
+            storeDns = preferences.getBoolean(KeyStoreDns, defaults.storeDns),
             transparentProxyPort = preferences.getString(
                 KeyTransparentProxyPort,
                 defaults.transparentProxyPort,
@@ -329,6 +331,8 @@ internal class AppSettingsPreferences(
             putBoolean(KeyDnsDisableCache, state.dnsDisableCache)
             putBoolean(KeyDnsDisableExpire, state.dnsDisableExpire)
             putString(KeyDnsTimeout, state.dnsTimeout)
+            putBoolean(KeyStoreFakeIp, state.storeFakeIp)
+            putBoolean(KeyStoreDns, state.storeDns)
             putString(KeyTransparentProxyPort, state.transparentProxyPort)
             putBoolean(KeyEnableRootBootScript, state.enableRootBootScript)
             putBoolean(KeyEnableRootEbpfRules, state.enableRootEbpfRules)
@@ -438,6 +442,8 @@ private const val KeyDnsOptimisticCache = "dns_optimistic_cache"
 private const val KeyDnsDisableCache = "dns_disable_cache"
 private const val KeyDnsDisableExpire = "dns_disable_expire"
 private const val KeyDnsTimeout = "dns_timeout"
+private const val KeyStoreFakeIp = "store_fake_ip"
+private const val KeyStoreDns = "store_dns"
 private const val KeyTransparentProxyPort = "transparent_proxy_port"
 private const val KeyEnableRootBootScript = "enable_root_boot_script"
 private const val KeyEnableRootEbpfRules = "enable_root_ebpf_rules"

--- a/app/src/main/kotlin/engine/singbox/config/SingBoxConfigCompiler.kt
+++ b/app/src/main/kotlin/engine/singbox/config/SingBoxConfigCompiler.kt
@@ -51,6 +51,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 
 internal const val APP_TAG_PREFIX = "__asteriskbox_"
 internal const val APP_GLOBAL_SELECTOR = "__asteriskbox_global__"

--- a/app/src/main/kotlin/engine/singbox/config/SingBoxConfigCompiler.kt
+++ b/app/src/main/kotlin/engine/singbox/config/SingBoxConfigCompiler.kt
@@ -167,6 +167,10 @@ internal object SingBoxConfigCompiler {
         )
 
         SingBoxDeprecatedConfigValidator.validate(runtime)
+        runtime = runtime.updated(
+            "experimental",
+            compileExperimental(appState),
+        )
         return runtime
     }
 }
@@ -996,5 +1000,16 @@ private fun JsonArray?.orEmptyObjects(): List<JsonObject> =
 
 private fun JsonObject.hasAppTag(): Boolean =
     ((this["tag"] as? JsonPrimitive)?.contentOrNull ?: "").startsWith(APP_TAG_PREFIX)
+
+private fun compileExperimental(appState: AppState): JsonObject? {
+    if (!appState.storeFakeIp && !appState.storeDns) return null
+    return buildJsonObject {
+        putJsonObject("cache_file") {
+            put("enabled", true)
+            if (appState.storeFakeIp) put("store_fakeip", true)
+            if (appState.storeDns) put("store_dns", true)
+        }
+    }
+}
 
 private val RouteRejectMethods = setOf("default", "drop", "reply")

--- a/app/src/main/kotlin/engine/singbox/config/SingBoxDeprecatedConfigValidator.kt
+++ b/app/src/main/kotlin/engine/singbox/config/SingBoxDeprecatedConfigValidator.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.contentOrNull
 
 internal object SingBoxDeprecatedConfigValidator {
     fun validate(root: JsonObject) {
-        rejectField(root, "experimental", "")
+        validateExperimental(root["experimental"] as? JsonObject)
         rejectField(root, "geoip", "")
         rejectField(root, "geosite", "")
 
@@ -21,6 +21,21 @@ internal object SingBoxDeprecatedConfigValidator {
         validateRoute(root["route"] as? JsonObject)
         validateRuleSets(root["route"] as? JsonObject)
         validateEveryObject(root, "")
+    }
+
+    private fun validateExperimental(experimental: JsonObject?) {
+        if (experimental == null) return
+        experimental.forEach { (name, _) ->
+            if (name != "cache_file") {
+                deprecated("/experimental/${jsonPointerToken(name)}")
+            }
+        }
+        val cacheFile = experimental["cache_file"] as? JsonObject ?: return
+        cacheFile.forEach { (name, _) ->
+            if (name !in AllowedCacheFileFields) {
+                deprecated("/experimental/cache_file/${jsonPointerToken(name)}")
+            }
+        }
     }
 
     private fun validateDns(dns: JsonObject?) {
@@ -157,6 +172,16 @@ internal object SingBoxDeprecatedConfigValidator {
         )
     }
 }
+
+private val AllowedCacheFileFields = setOf(
+    "enabled",
+    "path",
+    "cache_id",
+    "store_fakeip",
+    "store_rdrc",
+    "rdrc_timeout",
+    "store_dns",
+)
 
 private val DeprecatedInboundFields = setOf(
     "sniff",

--- a/app/src/main/kotlin/engine/singbox/config/SingBoxDnsCompiler.kt
+++ b/app/src/main/kotlin/engine/singbox/config/SingBoxDnsCompiler.kt
@@ -142,6 +142,7 @@ internal fun SingBoxDnsServerState.sanitized(): SingBoxDnsServerState =
         domainResolver = domainResolver.trim(),
         detour = detour.trim(),
         tlsServerName = tlsServerName.trim(),
+        servers = servers.toTrimmedNonEmptyDistinctList(),
     )
 
 internal fun SingBoxDnsRuleState.sanitized(): SingBoxDnsRuleState =
@@ -202,6 +203,9 @@ private fun SingBoxDnsServerState.toJson(): JsonObject = buildJsonObject {
                     }
                 }
             }
+        }
+        "group" -> {
+            putStringArrayIfNotEmpty("servers", servers)
         }
         "udp", "tcp" -> putNetworkServerFields(this@toJson, includeTls = false, includePath = false)
         "tls", "quic" -> putNetworkServerFields(this@toJson, includeTls = true, includePath = false)

--- a/app/src/main/kotlin/features/dns/DnsManagementSettings.kt
+++ b/app/src/main/kotlin/features/dns/DnsManagementSettings.kt
@@ -19,6 +19,8 @@ internal fun AppState.withDnsSettings(draft: DnsSettingsDraft): AppState {
         dnsDisableCache = draft.dnsDisableCache,
         dnsDisableExpire = draft.dnsDisableExpire,
         dnsTimeout = draft.dnsTimeout,
+        storeFakeIp = draft.storeFakeIp,
+        storeDns = draft.storeDns,
         dnsServers = draft.dnsServers,
         nextDnsServerId = draft.nextDnsServerId,
         dnsRules = dnsRules

--- a/app/src/main/kotlin/features/settings/SettingsDrafts.kt
+++ b/app/src/main/kotlin/features/settings/SettingsDrafts.kt
@@ -59,6 +59,8 @@ internal data class DnsSettingsDraft(
     val dnsDisableCache: Boolean = false,
     val dnsDisableExpire: Boolean = false,
     val dnsTimeout: String = "",
+    val storeFakeIp: Boolean = false,
+    val storeDns: Boolean = false,
     val dnsServers: List<SingBoxDnsServerState> = emptyList(),
     val nextDnsServerId: Int = 1,
     val dnsServerTagReplacements: Map<String, String> = emptyMap(),
@@ -75,6 +77,8 @@ internal fun AppState.toDnsSettingsDraft(): DnsSettingsDraft {
         dnsDisableCache = dnsDisableCache,
         dnsDisableExpire = dnsDisableExpire,
         dnsTimeout = dnsTimeout,
+        storeFakeIp = storeFakeIp,
+        storeDns = storeDns,
         dnsServers = dnsServers,
         nextDnsServerId = nextDnsServerId,
     )

--- a/app/src/main/kotlin/features/settings/sheets/DnsServerFieldLayout.kt
+++ b/app/src/main/kotlin/features/settings/sheets/DnsServerFieldLayout.kt
@@ -7,6 +7,7 @@ internal enum class DnsServerFieldKind {
     None,
     Local,
     Hosts,
+    Group,
     Network,
     Dhcp,
     Mdns,
@@ -25,6 +26,7 @@ internal fun dnsServerFieldLayout(serverType: String): DnsServerFieldLayout =
     when (serverType) {
         "local" -> DnsServerFieldLayout(DnsServerFieldKind.Local)
         "hosts" -> DnsServerFieldLayout(DnsServerFieldKind.Hosts)
+        "group" -> DnsServerFieldLayout(DnsServerFieldKind.Group)
         "udp", "tcp" -> DnsServerFieldLayout(DnsServerFieldKind.Network)
         "tls", "quic" -> DnsServerFieldLayout(
             kind = DnsServerFieldKind.Network,

--- a/app/src/main/kotlin/features/settings/sheets/DnsServerReferences.kt
+++ b/app/src/main/kotlin/features/settings/sheets/DnsServerReferences.kt
@@ -11,7 +11,9 @@ internal fun dnsDomainResolverChoices(
     currentIndex: Int?,
 ): List<ManagedReferenceChoice> =
     servers.withIndex()
-        .filter { (index, _) -> index != currentIndex }
+        .filter { (index, server) ->
+            index != currentIndex && server.type != "group"
+        }
         .map { (_, server) ->
             ManagedReferenceChoice(
                 tag = server.tag,
@@ -25,13 +27,21 @@ internal fun removeDnsServerAndReferences(
     index: Int,
 ): List<SingBoxDnsServerState> {
     val deletedTag = servers.getOrNull(index)?.tag?.trim() ?: return servers
-    return servers
+    val remaining = servers
         .filterIndexed { itemIndex, _ -> itemIndex != index }
         .map { server ->
-            if (server.domainResolver.trim() == deletedTag) {
-                server.copy(domainResolver = "")
-            } else {
-                server
-            }
+            server.copy(
+                domainResolver = server.domainResolver
+                    .takeUnless { it.trim() == deletedTag }
+                    .orEmpty(),
+                servers = if (server.type == "group") {
+                    server.servers.filter { member -> member != deletedTag }
+                } else {
+                    server.servers
+                },
+            )
         }
+    return remaining.filterNot { server ->
+        server.type == "group" && server.servers.isEmpty()
+    }
 }

--- a/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
+++ b/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
@@ -526,7 +526,7 @@ private fun DnsServerEditorSheet(
         null
     }
     val existingServerTags = existingServers
-        .filter { it.type != "group" }
+        .filter { it.type != "group" && it.type != "fakeip" }
         .map { it.tag.trim() }
         .filter(String::isNotEmpty)
     val groupServerError = if (server.type == "group") {
@@ -646,7 +646,7 @@ private fun DnsServerEditorSheet(
                     }
                     DnsServerFieldKind.Group -> {
                     val groupServerChoices = existingServers
-                        .filter { it.type != "group" }
+                        .filter { it.type != "group" && it.type != "fakeip" }
                         .map { it.tag.trim() to it.remarks.ifBlank { dnsServerTypeLabel(it.type) } }
                     ReferenceSelectionCard(
                         title = stringResource(R.string.settings_dns_group_servers),

--- a/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
+++ b/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
@@ -319,6 +319,27 @@ internal fun DnsSettingsBottomSheet(
                         label = stringResource(R.string.settings_dns_timeout),
                         errorText = timeoutError,
                     )
+                    val hasFakeIpServer = draft.dnsServers.any { it.type == "fakeip" }
+                    AnimatedVisibility(
+                        visible = hasFakeIpServer,
+                        enter = AsteriskMotion.contentEnter(),
+                        exit = AsteriskMotion.contentExit(),
+                    ) {
+                        SwitchPreference(
+                            title = stringResource(R.string.settings_dns_store_fake_ip),
+                            icon = Icons.Rounded.Storage,
+                            summary = stringResource(R.string.settings_dns_store_fake_ip_summary),
+                            checked = draft.storeFakeIp,
+                            onCheckedChange = { onDraftChange(draft.copy(storeFakeIp = it)) },
+                        )
+                    }
+                    SwitchPreference(
+                        title = stringResource(R.string.settings_dns_store_dns),
+                        icon = Icons.Rounded.History,
+                        summary = stringResource(R.string.settings_dns_store_dns_summary),
+                        checked = draft.storeDns,
+                        onCheckedChange = { onDraftChange(draft.copy(storeDns = it)) },
+                    )
                 }
 
                 DnsSheetSection(title = stringResource(R.string.settings_dns_section_servers)) {

--- a/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
+++ b/app/src/main/kotlin/features/settings/sheets/DnsSettingsBottomSheet.kt
@@ -525,6 +525,20 @@ private fun DnsServerEditorSheet(
     } else {
         null
     }
+    val existingServerTags = existingServers
+        .filter { it.type != "group" }
+        .map { it.tag.trim() }
+        .filter(String::isNotEmpty)
+    val groupServerError = if (server.type == "group") {
+        val validServers = server.servers.filter { it in existingServerTags }
+        if (validServers.isEmpty()) {
+            stringResource(R.string.settings_dns_group_servers_required)
+        } else {
+            null
+        }
+    } else {
+        null
+    }
     val portError = server.serverPort.trim()
         .takeIf(String::isNotEmpty)
         ?.let { value ->
@@ -537,6 +551,7 @@ private fun DnsServerEditorSheet(
         endpointError,
         serviceError,
         fakeIpError,
+        groupServerError,
         portError,
     ).all { it == null }
     val fieldSizeMotion = AsteriskMotion.contentSpatial<IntSize>()
@@ -627,6 +642,26 @@ private fun DnsServerEditorSheet(
                         validateInput = { value ->
                             dnsPredefinedHostError(value, hostsInvalidMessage)
                         },
+                    )
+                    }
+                    DnsServerFieldKind.Group -> {
+                    val groupServerChoices = existingServers
+                        .filter { it.type != "group" }
+                        .map { it.tag.trim() to it.remarks.ifBlank { dnsServerTypeLabel(it.type) } }
+                    ReferenceSelectionCard(
+                        title = stringResource(R.string.settings_dns_group_servers),
+                        emptyText = stringResource(R.string.settings_dns_group_servers_empty),
+                        choices = groupServerChoices,
+                        selected = server.servers.toSet(),
+                        onToggle = { tag ->
+                            val nextValues = if (tag in server.servers) {
+                                server.servers - tag
+                            } else {
+                                server.servers + tag
+                            }
+                            onEditorChange(server.copy(servers = nextValues))
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp),
                     )
                     }
                     DnsServerFieldKind.Network -> {
@@ -1680,6 +1715,9 @@ private fun dnsServerSummary(
                 stringResource(R.string.settings_dns_host_port, address, port)
             } ?: address
         }
+        "group" -> server.servers.takeIf(List<String>::isNotEmpty)
+            ?.joinToString(", ")
+            ?: stringResource(R.string.settings_dns_group_servers_empty)
         "fakeip" -> server.inet4Range.ifBlank { DefaultSingBoxDnsFakeIpRange }
         in EndpointDnsServerTypes ->
             visibleManagedReference(server.endpoint, endpointLabels, unavailableLabel)
@@ -1723,6 +1761,7 @@ internal fun dnsServerTypeLabel(type: String): String =
 private fun dnsServerTypeLabelResource(type: String): Int = when (type) {
     "local" -> R.string.settings_dns_server_type_local
     "hosts" -> R.string.settings_dns_server_type_hosts
+    "group" -> R.string.settings_dns_server_type_group
     "udp" -> R.string.settings_dns_server_type_udp
     "tcp" -> R.string.settings_dns_server_type_tcp
     "tls" -> R.string.settings_dns_server_type_tls

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1148,6 +1148,10 @@
     <string name="proxy_app_list_shared_uid_value">SUID：%1$s</string>
     <string name="settings_dns_server_type_local">本地解析器</string>
     <string name="settings_dns_server_type_hosts">Hosts</string>
+    <string name="settings_dns_server_type_group">分组</string>
+    <string name="settings_dns_group_servers">成员服务器</string>
+    <string name="settings_dns_group_servers_empty">尚未选择成员服务器</string>
+    <string name="settings_dns_group_servers_required">请至少选择一个服务器</string>
     <string name="settings_dns_server_type_udp">UDP</string>
     <string name="settings_dns_server_type_tcp">TCP</string>
     <string name="settings_dns_server_type_tls">TLS</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -445,6 +445,10 @@
     <string name="settings_dns_disable_cache">禁用 DNS 缓存</string>
     <string name="settings_dns_disable_expire">禁用 DNS 缓存过期</string>
     <string name="settings_dns_timeout">默认超时时间</string>
+    <string name="settings_dns_store_fake_ip">持久化 FakeIP 映射</string>
+    <string name="settings_dns_store_fake_ip_summary">重启后域名保持相同的 FakeIP 地址</string>
+    <string name="settings_dns_store_dns">持久化 DNS 缓存</string>
+    <string name="settings_dns_store_dns_summary">将 DNS 缓存保存到磁盘，重启后仍然有效</string>
     <string name="settings_dns_duration_invalid">请输入类似 10s 或 500ms 的时间</string>
     <string name="settings_dns_servers_empty">还没有添加 DNS 服务器</string>
     <string name="settings_dns_server_required">至少需要一个有效的 DNS 服务器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1167,6 +1167,10 @@
     <string name="proxy_app_list_shared_uid_value">SUID: %1$s</string>
     <string name="settings_dns_server_type_local">Local resolver</string>
     <string name="settings_dns_server_type_hosts">Hosts</string>
+    <string name="settings_dns_server_type_group">Group</string>
+    <string name="settings_dns_group_servers">Member servers</string>
+    <string name="settings_dns_group_servers_empty">No member servers selected</string>
+    <string name="settings_dns_group_servers_required">Select at least one server</string>
     <string name="settings_dns_server_type_udp">UDP</string>
     <string name="settings_dns_server_type_tcp">TCP</string>
     <string name="settings_dns_server_type_tls">TLS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,6 +450,10 @@
     <string name="settings_dns_disable_cache">Disable DNS cache</string>
     <string name="settings_dns_disable_expire">Disable cache expiration</string>
     <string name="settings_dns_timeout">Default timeout</string>
+    <string name="settings_dns_store_fake_ip">Persist FakeIP mappings</string>
+    <string name="settings_dns_store_fake_ip_summary">Keep the same FakeIP address for each domain after restart</string>
+    <string name="settings_dns_store_dns">Persist DNS cache</string>
+    <string name="settings_dns_store_dns_summary">Save DNS cache to disk so it survives restarts</string>
     <string name="settings_dns_duration_invalid">Use a duration such as 10s or 500ms</string>
     <string name="settings_dns_servers_empty">No DNS servers added</string>
     <string name="settings_dns_server_required">At least one valid DNS server is required</string>

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -18,7 +18,7 @@ object ProjectConfig {
     const val BPF_MATCHER_VERSION = "v1.0.0"
     const val SETUIDGID_VERSION = "v1.0.0"
     const val SING_BOX_VERSION = "v1.14.0-beta.5-reF1nd"
-    const val ANDROID_LIB_BOX_LITE_VERSION = "v1.14.0-beta.5"
+    const val ANDROID_LIB_BOX_LITE_VERSION = "v1.14.0-beta.5-reF1nd"
     const val HEV_SOCKS5_TUNNEL_VERSION = "2.16.0"
     const val TARGET_SDK = 37
     const val MIN_SDK = 24

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -17,8 +17,8 @@ object ProjectConfig {
     const val BPF2SOCKS_VERSION = "v1.0.3"
     const val BPF_MATCHER_VERSION = "v1.0.0"
     const val SETUIDGID_VERSION = "v1.0.0"
-    const val SING_BOX_VERSION = "v1.14.0-beta.5-reF1nd"
     const val ANDROID_LIB_BOX_LITE_VERSION = "v1.14.0-beta.5-reF1nd"
+    const val SING_BOX_VERSION = ANDROID_LIB_BOX_LITE_VERSION
     const val HEV_SOCKS5_TUNNEL_VERSION = "2.16.0"
     const val TARGET_SDK = 37
     const val MIN_SDK = 24


### PR DESCRIPTION
## 改动点

1. **FakeIP / DNS 缓存持久化**：新增 `experimental.cache_file`（`store_fakeip`、`store_dns`）开关，DNS 设置页可配置，重启后保持 FakeIP 映射与 DNS 缓存。

2. **DNS group 服务器类型**：支持 reF1nd/sing-box 的 `group` DNS 服务器（成员选择、引用清理、空组删除）。

3. **validator 放行生成的 `experimental.cache_file`**，仍拒绝其他 experimental（clash_api 等）。

> 说明：DNS group 依赖 reF1nd/sing-box 核心（见 AndroidLibBoxLite PR #1），libbox 切到 reF1nd 后即可用。配置校验统一走 libbox `checkConfig`。